### PR TITLE
Previne sobrecarga de processamento se necessário

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -12,7 +12,7 @@ class Plugin extends \MapasCulturais\Plugin {
         $app->hook('auth.login', function($user) use($app){
             /** @var User $user */
             // $agents = $app->repo('Agent')->findBy(['user' => $user, '_type' => 1]);
-            $preventOverhead = (bool) $user->metadata['preventOverhead'] ?? false;
+            $preventOverhead = (bool) ($user->metadata['preventOverhead'] ?? false);
             if (!$preventOverhead) {
                 $agents = $app->repo('Agent')->findBy(['user' => $user]);
                 foreach($agents as $agent) {

--- a/Plugin.php
+++ b/Plugin.php
@@ -12,9 +12,12 @@ class Plugin extends \MapasCulturais\Plugin {
         $app->hook('auth.login', function($user) use($app){
             /** @var User $user */
             // $agents = $app->repo('Agent')->findBy(['user' => $user, '_type' => 1]);
-            $agents = $app->repo('Agent')->findBy(['user' => $user]);
-            foreach($agents as $agent) {
-                $app->enqueueEntityToPCacheRecreation($agent);
+            $preventOverhead = (bool) $user->metadata['preventOverhead'] ?? false;
+            if (!$preventOverhead) {
+                $agents = $app->repo('Agent')->findBy(['user' => $user]);
+                foreach($agents as $agent) {
+                    $app->enqueueEntityToPCacheRecreation($agent);
+                }
             }
         });
     }


### PR DESCRIPTION
### Contexto

O plugin recria todas as permissões para todos os agentes vinculados ao acesso corrente durante o login. Ocorre que usuários com muitos agentes são impactados com um processamento pesado e acabam obtendo estouro de tempo (timeout) e erro durante o login, a exemplo da Secretaria de Cidadania e Diversidade Cultural (SCDC) do Ministério da Cultura que não conseguia completar o login por agregar milhares de agentes.

### Intervenção

Consideramos a existência de uma _flag_ chamada "preventOverhead" e inibimos este processamento no caso dessa flag estar ativada.

### Retrocompatibilidade

Para garantir retrocompatibilidade em ambientes que utilizem este plugin e não tenham essa _flag_, mantivemos o processamento nos demais casos, ou seja, o plugin continua como antes se a _flag_ não existir.